### PR TITLE
Дать человеко-понятные имена переменным

### DIFF
--- a/по буквам предложение.pas
+++ b/по буквам предложение.pas
@@ -1,18 +1,17 @@
 ﻿program letters;
-var pred1:string;
-var i, a, letter: integer;
+var sentense:string;
+var i, index: integer;
 begin
-i :=0;
-a := 0;
-letter := 1;
+length :=0;
+index := 1;
 writeln('Введите предложение');
-readln(pred1);
-writeln(pred1);
-i := length(pred1);
+readln(sentense);
+writeln(sentense);
+length := length(pred1);
 
-while letter <= i do begin
-writeln(pred1[letter]);
-letter := letter + 1;
+while index <= length do begin
+writeln(sentense[index]);
+index := index + 1;
 end;
 
 end.

--- a/по буквам предложение.pas
+++ b/по буквам предложение.pas
@@ -2,14 +2,13 @@
 var sentense:string;
 var i, index: integer;
 begin
-length :=0;
 index := 1;
 writeln('Введите предложение');
 readln(sentense);
 writeln(sentense);
-length := length(pred1);
 
-while index <= length do begin
+while index <= length(sentense) do begin
+
 writeln(sentense[index]);
 index := index + 1;
 end;


### PR DESCRIPTION
смотри, тут всё правильно, но для того чтобы это читать было удобно стоит использовать понятные имена переменных
переменную `a` видимо хотели использовать, но не получилось — стоит убирать
имя переменной `i` есть смысл использовать для индекса, для длинны лучше использовать имя `length` или уж `l`, в крайнем случае
`pred1` лучше никогда не использовать :)